### PR TITLE
Allow --username parameter to specify AWS credentials profile name

### DIFF
--- a/lektor_s3.py
+++ b/lektor_s3.py
@@ -158,7 +158,7 @@ class S3Publisher(Publisher):
         )
 
     def connect(self, credentials):
-        session = boto3.Session(profile_name=credentials['username'])
+        session = boto3.Session(profile_name=credentials.get('username'))
         self.s3 = session.resource(service_name='s3')
 
     def publish(self, target_url, credentials=None):

--- a/lektor_s3.py
+++ b/lektor_s3.py
@@ -158,7 +158,8 @@ class S3Publisher(Publisher):
         )
 
     def connect(self, credentials):
-        self.s3 = boto3.resource(service_name='s3')
+        session = boto3.Session(profile_name=credentials['username'])
+        self.s3 = session.resource(service_name='s3')
 
     def publish(self, target_url, credentials=None):
         if credentials is None:


### PR DESCRIPTION
For people who use profiles in their .aws/credentials to handle multiple accounts, this pull request adds the ability to specify the profile name using the --username parameter. If parameter not set, default profile will be used.
