### PR TITLE
Invalidate Cloudfront

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ website to S3 in the bucket you targeted.
 ## CloudFront ##
 
 Optionally, you can also provide a [CloudFront](https://aws.amazon.com/cloudfront/)
-distribution ID. If you do, Lektor will invalidate all objects in CloudFront that
-have just been deployed on S3.
+distribution ID. If you do, Lektor will invalidate all objects in that CloudFront
+distribution after every deploy.
 
 ```ini
 cloudfront = <YOUR-DISTRIBUTION-ID>

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ lektor-s3 makes it easy to deploy your
 ## Before you start ##
 
 You're going to be storing your website's data in an S3 bucket. The code
-here won't do anything to create or configure that bucket. You'll have to 
-create the S3 bucket and set it up yourself. 
+here won't do anything to create or configure that bucket. You'll have to
+create the S3 bucket and set it up yourself.
 
 AWS has a [pretty good guide](http://docs.aws.amazon.com/gettingstarted/latest/swh/website-hosting-intro.html)
-for how to set up a bucket to host a static website. You'll need to both 
+for how to set up a bucket to host a static website. You'll need to both
 create the bucket and set its permissions to allow global read access.
 Remember to do this **first** because lektor-s3 won't do it automatically.
 
@@ -43,6 +43,16 @@ target = s3://huntedwumpus
 
 Now, if you call `lektor deploy s3`, Lektor will upload your built
 website to S3 in the bucket you targeted.
+
+## CloudFront ##
+
+Optionally, you can also provide a [CloudFront](https://aws.amazon.com/cloudfront/)
+distribution ID. If you do, Lektor will invalidate all objects in CloudFront that
+have just been deployed on S3.
+
+```ini
+cloudfront = <YOUR-DISTRIBUTION-ID>
+```
 
 ## Credentials ##
 

--- a/lektor_s3.py
+++ b/lektor_s3.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import mimetypes
 import os
+import time
 from hashlib import md5
 
 from lektor.publisher import Publisher, PublishError
@@ -30,6 +31,7 @@ class S3Publisher(Publisher):
         self.s3 = None
         self.bucket = None
         self.key_prefix = ''
+        self.cloudfront = None
 
     def split_bucket_uri(self, target_url):
         bucket = target_url.netloc
@@ -159,8 +161,9 @@ class S3Publisher(Publisher):
 
     def connect(self, credentials):
         self.s3 = boto3.resource(service_name='s3')
+        self.cloudfront = boto3.client(service_name='cloudfront')
 
-    def publish(self, target_url, credentials=None, **extra):
+    def publish(self, target_url, credentials=None, server_info=None, **extra):
         if credentials is None:
             credentials = {}
         self.connect(credentials)
@@ -189,4 +192,23 @@ class S3Publisher(Publisher):
             yield 'deleting %s' % f
         self.delete_batch(diff['delete'])
 
-
+        # should we invalidate cloudfront?
+        # only invalidate added and updated files; leave deleted as they are
+        changed = diff['add'] + diff['update']
+        if server_info and changed:
+            distribution_id = server_info.extra.get("cloudfront")
+        else:
+            distribution_id = None
+        if distribution_id:
+            ref = "lektor{time}".format(time=time.time())
+            self.cloudfront.create_invalidation(
+                DistributionId=distribution_id,
+                InvalidationBatch={
+                    'Paths': {
+                        'Quantity': len(changed),
+                        'Items': ['/{}'.format(file) for file in changed],
+                    },
+                    'CallerReference': ref,
+                }
+            )
+            yield 'invalidated {num} paths in CloudFront'.format(num=len(changed))


### PR DESCRIPTION
I use [CloudFront](https://aws.amazon.com/cloudfront/) in front of my S3-hosted site, so that I can use [AWS Certificate Manager to get HTTPS on my site](https://aws.amazon.com/blogs/aws/new-aws-certificate-manager-deploy-ssltls-based-apps-on-aws/). However, this means that every time I deploy to my S3 bucket, I need to invalidate objects in CloudFront. This pull request automates that process.
