### PR TITLE
Update setup.py for automatic listing by Lektor website

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='Lektor plugin to support publishing to S3',
     long_description=readme,
     long_description_content_type='text/markdown',
-    version='0.5.0',
+    version='0.5.1',
     author='Spencer Nelson',
     author_email='s@spenczar.com',
     url='https://github.com/spenczar/lektor-s3',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-with open('README.md', 'rt', encoding='utf8') as readme_file:
+with open('README.md') as readme_file:
     readme = readme_file.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
 from setuptools import setup
 
+with open('README.md', 'rt', encoding='utf8') as readme_file:
+    readme = readme_file.read()
+
 setup(
     name='lektor-s3',
     description='Lektor plugin to support publishing to S3',
-    version='0.4.0',
+    long_description=readme,
+    long_description_content_type='text/markdown',
+    version='0.5.0',
     author='Spencer Nelson',
     author_email='s@spenczar.com',
     url='https://github.com/spenczar/lektor-s3',
@@ -29,7 +34,9 @@ setup(
     ],
     classifiers=[
         'Development Status :: 4 - Beta',
+        'Environment :: Plugins',
         'Environment :: Web Environment',
+        'Framework :: Lektor',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
As laid out in https://github.com/lektor/lektor-website/issues/203 and associated issues linked there, the Lektor project's website is changing to pull plugin lists automatically from PyPI. For this to work, plugins need to have proper information registered in PyPI, which is done with a few changes to setup.py.

Updating the metadata in PyPI requires bumping the version number.

cc @nixjdm - could you take a look over this and make sure I've ticked all the right boxes?